### PR TITLE
Added the ability to specify what HTTP method to use.

### DIFF
--- a/lib/em-eventsource.rb
+++ b/lib/em-eventsource.rb
@@ -29,14 +29,20 @@ module EventMachine
     # The connection is not open, and the user agent is not trying to reconnect. Either there was a fatal error or the close() method was invoked.
     CLOSED     = 2
 
+    HTTP_METHODS = EM::HTTPMethods.public_instance_methods
+
     # Create a new stream
     #
     # url - the url as string
     # query - the query string as hash
     # headers - the headers for the request as hash
-    def initialize(url, query={}, headers={})
+    # method - the HTTP method to use for the request (see EM::HTTPMethods)
+    def initialize(url, query={}, headers={}, method=:get)
+      raise ArgumentError, "acceptable methods: #{HTTP_METHODS.map { |s| ":#{s}" }.join(', ')}" unless HTTP_METHODS.include?(method)
+
       @url = url
       @query = query
+      @method = method
       @headers = headers
       @ready_state = CLOSED
 
@@ -185,8 +191,7 @@ module EventMachine
       }
       headers = @headers.merge({'Cache-Control' => 'no-cache', 'Accept' => 'text/event-stream'})
       headers.merge!({'Last-Event-Id' => @last_event_id }) if not @last_event_id.nil?
-      [conn, conn.get({ :query => @query,
-                        :head  => headers})]
+      [conn, conn.public_send(@method, { :query => @query, :head  => headers})]
     end
   end
 end

--- a/spec/em-eventsource_spec.rb
+++ b/spec/em-eventsource_spec.rb
@@ -29,7 +29,7 @@ describe EventMachine::EventSource do
       source.url.must_equal "http://example.com/streaming"
       req.url.must_equal "http://example.com/streaming"
       req.opts[:inactivity_timeout].must_equal 60
-      req.get_args[0].must_equal({ :query => {},
+      req.req_args[0].must_equal({ :query => {},
                                    :head  => {"Cache-Control" => "no-cache",
                                               "Accept" => "text/event-stream"} })
       EM.stop
@@ -39,7 +39,7 @@ describe EventMachine::EventSource do
   it "connect to the good server with query and headers" do
     start_source "http://example.net/streaming", {:chuck => "norris"}, {"DNT" => 1} do |source, req|
       req.url.must_equal "http://example.net/streaming"
-      req.get_args[0].must_equal({ :query => {:chuck => "norris"},
+      req.req_args[0].must_equal({ :query => {:chuck => "norris"},
                                    :head  => {"DNT" => 1,
                                               "Cache-Control" => "no-cache",
                                               "Accept" => "text/event-stream"} })
@@ -157,7 +157,7 @@ describe EventMachine::EventSource do
               req2 = source.instance_variable_get "@req"
               refute_same(req2, req)
               source.last_event_id.must_equal "roger"
-              req2.get_args[0].must_equal({ :head => { "Last-Event-Id" => "roger",
+              req2.req_args[0].must_equal({ :head => { "Last-Event-Id" => "roger",
                                                        "Accept" => "text/event-stream",
                                                        "Cache-Control" => "no-cache" },
                                             :query => {} })
@@ -178,7 +178,7 @@ describe EventMachine::EventSource do
               req2 = source.instance_variable_get "@req"
               refute_same(req2, req)
               source.last_event_id.must_equal "roger"
-              req2.get_args[0].must_equal({ :head => { "Last-Event-Id" => "roger",
+              req2.req_args[0].must_equal({ :head => { "Last-Event-Id" => "roger",
                                                        "Accept" => "text/event-stream",
                                                        "Cache-Control" => "no-cache" },
                                             :query => {} })
@@ -222,6 +222,16 @@ describe EventMachine::EventSource do
       source.start
       req = source.instance_variable_get "@req"
       req.opts[:inactivity_timeout].must_equal 0
+      EM.stop
+    end
+  end
+
+  it "defaults to HTTP GET" do
+    EM.run do
+      source = EventMachine::EventSource.new("http://example.com/streaming")
+      source.start
+      req = source.instance_variable_get "@req"
+      req.method.must_equal :get
       EM.stop
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "em-eventsource"
 
 module EventMachine
   class MockHttpRequest
-    attr_reader :url, :get_args, :middlewares, :opts, :method
+    attr_reader :url, :req_args, :middlewares, :opts, :method
 
     def initialize(url, opts={})
       @url = url
@@ -12,15 +12,16 @@ module EventMachine
       @headers = []
       @middlewares = []
       @opts = opts
-      @method = :get
     end
 
     def get(*args)
-      @get_args = args
+      @req_args = args
+      @method = :get
       self
     end
 
     def post(*args)
+      @req_args = args
       @method = :post
       self
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "em-eventsource"
 
 module EventMachine
   class MockHttpRequest
-    attr_reader :url, :get_args, :middlewares, :opts
+    attr_reader :url, :get_args, :middlewares, :opts, :method
 
     def initialize(url, opts={})
       @url = url
@@ -12,10 +12,16 @@ module EventMachine
       @headers = []
       @middlewares = []
       @opts = opts
+      @method = :get
     end
 
     def get(*args)
       @get_args = args
+      self
+    end
+
+    def post(*args)
+      @method = :post
       self
     end
 


### PR DESCRIPTION
I added an optional parameter to `initialize` whereby you can specify the method using a symbol. The default is a GET request.

A list of supported HTTP methods is defined here:
https://github.com/igrigorik/em-http-request/blob/master/lib/em-http/http_connection.rb#L3
